### PR TITLE
changed handler class properties to protected

### DIFF
--- a/src/Workers/Handlers/ExampleHandler.php
+++ b/src/Workers/Handlers/ExampleHandler.php
@@ -9,7 +9,7 @@ class ExampleHandler implements Handler {
      * @param Task $task
      * @return array
      */
-    public static function handle(Aws $aws, Task $task)
+    public function handle(Aws $aws, Task $task)
     {
 
         $result = strtoupper($task->getInput("string"));

--- a/src/Workers/Handlers/Handler.php
+++ b/src/Workers/Handlers/Handler.php
@@ -11,6 +11,6 @@ use Phlow\Task;
  */
 interface Handler {
 
-    public static function handle(Aws $aws, Task $task);
+    public function handle(Aws $aws, Task $task);
 
 }

--- a/src/Workers/Handlers/Handler.php
+++ b/src/Workers/Handlers/Handler.php
@@ -11,9 +11,26 @@ use Phlow\Task;
  */
 abstract class Handler {
 
-    private $name = '';
-    private $version = '';
-    private $description = '';
-    private $icon = '';
+    protected $name = '';
+    protected $version = '';
+    protected $description = '';
+    protected $icon = '';
 
+    /**
+     * Returns the meta and schema for this handler, used for UI rendering and validation
+     *
+     * @return array
+     */
+    public function describe()
+    {
+        return [
+            'meta' => [
+                'name' => $this->name,
+                'version' => $this->version,
+                'description' => $this->description,
+                'icon' => $this->icon,
+            ],
+            'schema' => $this->getSchema()
+        ];
+    }
 }


### PR DESCRIPTION
I added the describe() method to the handler abstract class. This returns the meta and schema for this handler. 

This implied that I had to change the class properties (name, description, version and icon) to protected from private. This was done in order to allow concrete handler classes inheriting from the Handler class define their respective class variables.
