### PR TITLE
Handler properties visibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "lookaflyingdonkey/phlow",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "library",
   "description": "Uses AWS Simple Workflow Service to provide JSON based job flows",
   "keywords": ["flow", "aws", "swf", "workflow", "json"],

--- a/src/Workers/Handlers/ExampleHandler.php
+++ b/src/Workers/Handlers/ExampleHandler.php
@@ -54,21 +54,4 @@ class ExampleHandler extends Handler implements IHandler {
         }';
     }
 
-    /**
-     * Returns the meta and schema for this handler, used for UI rendering and validation
-     *
-     * @return array
-     */
-    public function describe()
-    {
-        return [
-            'meta' => [
-                'name' => $this->name,
-                'version' => $this->version,
-                'description' => $this->description,
-                'icon' => $this->icon
-            ],
-            'schema' => $this->getSchema()
-        ];
-    }
 }

--- a/src/Workers/Handlers/ExampleHandler.php
+++ b/src/Workers/Handlers/ExampleHandler.php
@@ -9,7 +9,7 @@ class ExampleHandler implements Handler {
      * @param Task $task
      * @return array
      */
-    public static function handle(Aws $aws, Task $task)
+    public function handle(Aws $aws, Task $task)
     {
 
         $result = strtoupper($task->getInput("string"));

--- a/src/Workers/Handlers/Handler.php
+++ b/src/Workers/Handlers/Handler.php
@@ -11,6 +11,6 @@ use Phlow\Task;
  */
 interface Handler {
 
-    public static function handle(Aws $aws, Task $task);
+    public function handle(Aws $aws, Task $task);
 
 }

--- a/src/Workers/Handlers/Handler.php
+++ b/src/Workers/Handlers/Handler.php
@@ -11,9 +11,26 @@ use Phlow\Task;
  */
 abstract class Handler {
 
-    private $name = '';
-    private $version = '';
-    private $description = '';
-    private $icon = '';
+    protected $name = '';
+    protected $version = '';
+    protected $description = '';
+    protected $icon = '';
 
+    /**
+     * Returns the meta and schema for this handler, used for UI rendering and validation
+     *
+     * @return array
+     */
+    public function describe()
+    {
+        return [
+            'meta' => [
+                'name' => $this->name,
+                'version' => $this->version,
+                'description' => $this->description,
+                'icon' => $this->icon,
+            ],
+            'schema' => $this->getSchema()
+        ];
+    }
 }


### PR DESCRIPTION
Started from the branch for #3, but per @lookaflyingdonkey request removed the example `describe()` method.
