### PR TITLE
Removed example describe method

### DIFF
--- a/src/Workers/Handlers/ExampleHandler.php
+++ b/src/Workers/Handlers/ExampleHandler.php
@@ -53,22 +53,4 @@ class ExampleHandler extends Handler implements IHandler {
           ]
         }';
     }
-
-    /**
-     * Returns the meta and schema for this handler, used for UI rendering and validation
-     *
-     * @return array
-     */
-    public function describe()
-    {
-        return [
-            'meta' => [
-                'name' => $this->name,
-                'version' => $this->version,
-                'description' => $this->description,
-                'icon' => $this->icon
-            ],
-            'schema' => $this->getSchema()
-        ];
-    }
 }


### PR DESCRIPTION
As a followup to #3, removed the describe method from the Example Handler as it has been implemented exactly the same way on the Handler class.
